### PR TITLE
Fix the Name resolution caused by removing UUIDHandler.

### DIFF
--- a/src/main/java/com/empcraft/holoplots/PSHoloUtil.java
+++ b/src/main/java/com/empcraft/holoplots/PSHoloUtil.java
@@ -2,16 +2,15 @@ package com.empcraft.holoplots;
 
 import com.gmail.filoghost.holographicdisplays.api.Hologram;
 import com.gmail.filoghost.holographicdisplays.api.HologramsAPI;
-import com.gmail.filoghost.holographicdisplays.api.VisibilityManager;
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.configuration.Captions;
 import com.plotsquared.core.generator.GridPlotWorld;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.PlotArea;
-import com.plotsquared.core.util.uuid.UUIDHandler;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.regions.CuboidRegion;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -64,8 +63,7 @@ public class PSHoloUtil implements IHoloUtil {
                 hologram.appendTextLine(translate(plot, Captions.OWNER_SIGN_LINE_2.getTranslated()));
                 hologram.appendTextLine(translate(plot, Captions.OWNER_SIGN_LINE_3.getTranslated()));
                 hologram.appendTextLine(translate(plot, Captions.OWNER_SIGN_LINE_4.getTranslated()));
-                VisibilityManager visibilityManager = hologram.getVisibilityManager();
-                visibilityManager.showTo(player);
+                hologram.getVisibilityManager().showTo(player);
             }
         }
     }
@@ -73,10 +71,10 @@ public class PSHoloUtil implements IHoloUtil {
     private String translate(Plot plot, String string) {
         String id = plot.getId().toString();
         String name;
-        if (plot.getOwners() == null) {
+        if (plot.getOwnerAbs() == null) {
             name = "unowned";
         } else {
-            name = UUIDHandler.getName(plot.getOwnerAbs());
+            name = Bukkit.getOfflinePlayer(plot.getOwnerAbs()).getName();
         }
         if (name == null) {
             name = "unknown";


### PR DESCRIPTION
This fixes the often reported issue of the NoSuchMethodError when running HoloPlots against a more recent PlotSquared Version.
I don't know about the semantics of UUIDHandler, though, so if it does something special, my simple approach might not be appropriate.
I will, however, prepare another PR which at least calls translate async (In theory I guess lines 61-67 could be async, but lets better be safe than sorry _and_ future proof), because when someone is flying through the server with high speed, uuid fetches _could_ lockup the main thread again and again.

Sidenote: Fixes the bug that getOwners() would never be null, getOwernsAbs would be.