### PR TITLE
Update holograms on PlotChangeOwnerEvent in correct way

### DIFF
--- a/src/main/java/com/plotsquared/holoplots/PSHoloUtil.java
+++ b/src/main/java/com/plotsquared/holoplots/PSHoloUtil.java
@@ -144,6 +144,14 @@ public class PSHoloUtil implements IHoloUtil {
     @Subscribe
     public void onPlotChangeOwner(PlotChangeOwnerEvent e) {
         final Plot plot = e.getPlot();
+        UUID owner = plot.getOwnerAbs();
+        if (owner != null) {
+            HoloPlotID id = new HoloPlotID(e.getPlotId(), owner);
+            Hologram hologram = PSHoloUtil.holograms.remove(id);
+            if (hologram != null) {
+                hologram.delete();
+            }
+        }
         final UUID uuid = e.getInitiator().getUUID();
         TaskManager.runTaskLater(() -> {
             Player p = Bukkit.getPlayer(uuid);

--- a/src/main/java/com/plotsquared/holoplots/PSHoloUtil.java
+++ b/src/main/java/com/plotsquared/holoplots/PSHoloUtil.java
@@ -143,15 +143,17 @@ public class PSHoloUtil implements IHoloUtil {
 
     @Subscribe
     public void onPlotChangeOwner(PlotChangeOwnerEvent e) {
-        final Plot plot = e.getPlot();
-        UUID owner = plot.getOwnerAbs();
-        if (owner != null) {
-            HoloPlotID id = new HoloPlotID(e.getPlotId(), owner);
+        // Info: The problem with just calling updatePlayer() is that the old owner UUID is unknown to that methode,
+        // so it can't find the hologram in the HashMap (different hash in the new HoloPlotID instance)
+        UUID oldOwner = e.getOldOwner();
+        if (oldOwner != null) {
+            HoloPlotID id = new HoloPlotID(e.getPlotId(), oldOwner);
             Hologram hologram = PSHoloUtil.holograms.remove(id);
             if (hologram != null) {
-                hologram.clearLines();
+                hologram.delete();
             }
         }
+        final Plot plot = e.getPlot();
         final UUID uuid = e.getInitiator().getUUID();
         TaskManager.runTaskLater(() -> {
             Player p = Bukkit.getPlayer(uuid);

--- a/src/main/java/com/plotsquared/holoplots/PSHoloUtil.java
+++ b/src/main/java/com/plotsquared/holoplots/PSHoloUtil.java
@@ -143,7 +143,7 @@ public class PSHoloUtil implements IHoloUtil {
 
     @Subscribe
     public void onPlotChangeOwner(PlotChangeOwnerEvent e) {
-        // Info: The problem with just calling updatePlayer() is that the old owner UUID is unknown to that methode,
+        // Info: The problem with just calling updatePlayer() is that the old owner UUID is unknown to that method,
         // so it can't find the hologram in the HashMap (different hash in the new HoloPlotID instance)
         UUID oldOwner = e.getOldOwner();
         if (oldOwner != null) {

--- a/src/main/java/com/plotsquared/holoplots/PSHoloUtil.java
+++ b/src/main/java/com/plotsquared/holoplots/PSHoloUtil.java
@@ -149,7 +149,7 @@ public class PSHoloUtil implements IHoloUtil {
             HoloPlotID id = new HoloPlotID(e.getPlotId(), owner);
             Hologram hologram = PSHoloUtil.holograms.remove(id);
             if (hologram != null) {
-                hologram.delete();
+                hologram.clearLines();
             }
         }
         final UUID uuid = e.getInitiator().getUUID();


### PR DESCRIPTION
## Overview
<!--  Please describe which issue this pull request targets.

If there is no issue, delete the "Fixes" part.
-->

Fixes #43 

## Description
This fixes a bug, where new holograms where created on PlotChangeOwnerEvent, but the old one wasn't removed. Because of that there was a huge stack of armorstands and unreadable text created over the time. With this pull request it is going to be deleted first and then the a new one ist created.

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
