### PR TITLE
Add configurable X/Z offset

### DIFF
--- a/src/main/java/com/plotsquared/holoplots/DefaultHoloPlots.java
+++ b/src/main/java/com/plotsquared/holoplots/DefaultHoloPlots.java
@@ -167,7 +167,8 @@ public class DefaultHoloPlots implements HoloPlots {
             return;
         }
         final org.bukkit.Location hologramLocation = new org.bukkit.Location(
-                world, signLocation.getX() + .5, signLocation.getY() + Configuration.OFFSET, signLocation.getZ() + .5
+                world, signLocation.getX() + .5 + Configuration.OFFSET_X, signLocation.getY() + Configuration.OFFSET_Y,
+                signLocation.getZ() + .5 + Configuration.OFFSET_Z
         );
 
         // Cancel potential pending update which is still loading metadata, as we want the newest change to have the highest

--- a/src/main/java/com/plotsquared/holoplots/config/Configuration.java
+++ b/src/main/java/com/plotsquared/holoplots/config/Configuration.java
@@ -23,8 +23,14 @@ public class Configuration extends Config {
             "signs.owner_sign_line_4"
     );
 
+    @Comment("Determines the offset on the x-axis from the signs location where the hologram should spawn")
+    public static int OFFSET_X = 0;
+
     @Comment("Determines the offset on the y-axis from the signs location where the hologram should spawn")
-    public static int OFFSET = 6;
+    public static int OFFSET_Y = 6;
+
+    @Comment("Determines the offset on the z-axis from the signs location where the hologram should spawn")
+    public static int OFFSET_Z = 0;
 
     @Comment({
             "The skull to be shown if the plot is owned by the server (as defined by the server-plot flag).",


### PR DESCRIPTION
## Overview
Simply adds a configurable X/Z offset, as I needed that and might be useful to others.

## Description
It renames 'offset' to 'offset_y' and adds 'offset_x' + 'offset_z' as I didnt want the hologram to appear on top of the road, but rather the border.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [ ] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
