### PR TITLE
Improved logic to determine which plots to update on chunk load/unload

### DIFF
--- a/src/main/java/com/plotsquared/holoplots/listener/ChunkListener.java
+++ b/src/main/java/com/plotsquared/holoplots/listener/ChunkListener.java
@@ -44,15 +44,28 @@ public class ChunkListener implements org.bukkit.event.Listener {
             if (!(area instanceof GridPlotWorld gridPlotWorld)) {
                 continue;
             }
-            PlotId top = gridPlotWorld.getPlotManager().getPlotIdAbs(bx + 15, 0, bz + 15);
-            if (top == null) { //Top corner of plot, or assume entirely road
-                continue;
+
+            Set<Plot> seen = new HashSet<>();
+            int[][] corners = {{bx, bz}, {bx + 15, bz}, {bx, bz + 15}, {bx + 15, bz + 15}};
+            for (int[] corner : corners) {
+                PlotId plotId = gridPlotWorld.getPlotManager().getPlotIdAbs(corner[0], 0, corner[1]);
+                if (plotId == null) {
+                    continue;
+                }
+                Plot plot = gridPlotWorld.getPlotAbs(plotId);
+                // Because we check for 4 corners, the same plot may be returned multiple times, so we keep track of which ones we've already processed
+                if (plot == null || !seen.add(plot)) {
+                    continue;
+                }
+
+                // Only process if the plot's sign location falls within this chunk,
+                // preventing the same plot from being processed by multiple chunk events
+                Location signLoc = gridPlotWorld.getPlotManager().getSignLoc(plot);
+                if (signLoc.getX() >> 4 != chunk.getX() || signLoc.getZ() >> 4 != chunk.getZ()) {
+                    continue;
+                }
+                consumer.accept(plot);
             }
-            Plot plot = gridPlotWorld.getPlotAbs(top);
-            if (plot == null) {
-                continue;
-            }
-            consumer.accept(plot);
         }
     }
 

--- a/src/main/java/com/plotsquared/holoplots/listener/ChunkListener.java
+++ b/src/main/java/com/plotsquared/holoplots/listener/ChunkListener.java
@@ -45,11 +45,11 @@ public class ChunkListener implements org.bukkit.event.Listener {
                 continue;
             }
 
-            Set<Plot> seen = new HashSet<>();
+            Set<PlotId> seen = new HashSet<>();
             int[][] corners = {{bx, bz}, {bx + 15, bz}, {bx, bz + 15}, {bx + 15, bz + 15}};
             for (int[] corner : corners) {
                 PlotId plotId = gridPlotWorld.getPlotManager().getPlotIdAbs(corner[0], 0, corner[1]);
-                if (plotId == null) {
+                if (plotId == null || !seen.add(plotId)) {
                     continue;
                 }
                 Plot plot = gridPlotWorld.getPlotAbs(plotId);
@@ -65,6 +65,7 @@ public class ChunkListener implements org.bukkit.event.Listener {
                     continue;
                 }
                 consumer.accept(plot);
+                break;
             }
         }
     }


### PR DESCRIPTION
## Overview

## Description
I noticed high usage from this plugin when it comes to joining an empty plot world, after debugging I found out that it called `createOrUpdateHologram` multiple times for the same plot, sometimes up to 11 times.

To mitigate this issue, I check the 4 corners of the loaded chunk and check if the sign position falls within this chunk. Whilst also keeping track we haven't processed this chunk yet. This reduced my updates from 6-11 per plot to 1. 

Open to feedback, this solution made sense to me as the sign location is 'one case'.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md). 